### PR TITLE
feat(minio): Apply systemd-hardening to minio unit

### DIFF
--- a/debian/minio.service
+++ b/debian/minio.service
@@ -1,11 +1,26 @@
 [Unit]
 Description=High Performance Object Storage
 After=network.target
+AssertFileIsExecutable=/usr/bin/minio
+AssertFileIsExecutable=/usr/bin/minio-truenas
+AssertFileIsExecutable=/usr/bin/minio-truenas-prepare
 
 [Service]
+ExecStartPre=+/usr/bin/minio-truenas-prepare
 ExecStart=/usr/bin/minio-truenas
+User=minio
+Group=minio
 Restart=on-failure
 RestartSec=10
+
+NoNewPrivileges=yes
+ProtectProc=invisible
+ProtectSystem=strict
+ProtectHome=yes
+RestrictSUIDSGID=yes
+ReadWritePaths=/mnt
+ProtectClock=yes
+PrivateTmp=false
 
 [Install]
 WantedBy=multi-user.target

--- a/debian/rules
+++ b/debian/rules
@@ -12,6 +12,7 @@ override_dh_install:
 	mkdir -p debian/minio/usr/bin
 	cp minio debian/minio/usr/bin
 	cp minio-truenas debian/minio/usr/bin
+	cp minio-truenas-prepare debian/minio/usr/bin
 
 override_dh_installsystemd:
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=minio

--- a/minio-truenas
+++ b/minio-truenas
@@ -11,15 +11,8 @@ with Client() as c:
         sys.stderr.write(f'{s3["storage_path"]} does not exist or is not a directory\n')
         sys.exit(1)
 
-    os.chown(
-        s3["storage_path"],
-        c.call('dscache.get_uncached_user', 'minio')['pw_uid'],
-        c.call('dscache.get_uncached_group', 'minio')['gr_gid'],
-    )
-
     cmd = [
-        "sudo", "-E", "-u", "minio",
-        "minio", "server",
+        "server",
         "-S", "/usr/local/etc/minio/certs",
         "--address", f'{s3["bindip"]}:{s3["bindport"]}',
         "--console-address", f'{s3["bindip"]}:{s3["console_bindport"]}',
@@ -36,6 +29,6 @@ with Client() as c:
         os.environ["MINIO_BROWSER"] = "off"
 
     os.execv(
-        b"/usr/bin/sudo",
+        b"/usr/bin/minio",
         [arg.encode() for arg in cmd],
     )

--- a/minio-truenas-prepare
+++ b/minio-truenas-prepare
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+import os
+import sys
+
+from middlewared.client import Client
+
+with Client() as c:
+    s3 = c.call("s3.config")
+
+    if not os.path.isdir(s3["storage_path"]):
+        sys.stderr.write(f'{s3["storage_path"]} does not exist or is not a directory\n')
+        sys.exit(1)
+
+    os.chown(
+        s3["storage_path"],
+        c.call('dscache.get_uncached_user', 'minio')['pw_uid'],
+        c.call('dscache.get_uncached_group', 'minio')['gr_gid'],
+    )


### PR DESCRIPTION
This patch reworks the minio integration to use systemd hardening features This will help to protect the system from unexpected harm. It's achieved by splitting the start script into two parts, one for setting up the permissions, requiring root, and one starting minio as before.

Further systemd will now make sure, that all binaries are where they are supposed to be and executable.

Finally we isolate the execution environment from the rest of the system by using `ProtectProc`, `ProtectSystem` and `ProtectHome`, allowing only read-write operations on `/mnt` where our pools are located. Finally we explicitly don't want PrivateTmp, since our home directory is in `/var/tmp` and would be deleted when the service exists.